### PR TITLE
Check this out!

### DIFF
--- a/mta
+++ b/mta
@@ -15,3 +15,15 @@ with open("mta.dat", "rb+") as binary_file:
     print(file_data)
     data2 = file_data.decode('utf-8', 'ignore')
     print(data2)
+    
+### see: https://github.com/google/gtfs-realtime-bindings/issues/17
+### pip3 install gtfs-realtime-bindings
+#from google.transit import gtfs_realtime_pb2
+#import urllib
+#
+#feed = gtfs_realtime_pb2.FeedMessage()
+#response = urllib.urlopen('URL OF YOUR GTFS-REALTIME SOURCE GOES HERE')
+#feed.ParseFromString(response.read())
+#for entity in feed.entity:
+#  if entity.HasField('trip_update'):
+#    print (entity.trip_update)


### PR DESCRIPTION
However Python3 has a damaged file: 
File "mta_2.py", line 8, in <module>
    from google.transit import gtfs_realtime_pb2, nyct_subway_pb2
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/google/transit/gtfs_realtime_pb2.py", line 366, in <module>
    has_default_value=False, default_value=unicode("", "utf-8"),
NameError: name 'unicode' is not defined